### PR TITLE
git: ensure VSCode files are highlighted as jsonc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 # GitHub Actions CI doesn't have "native" solution for this
 # See https://github.com/actions/checkout/issues/226
 *.ts text eol=lf
+language-configuration.json linguist-language=jsonc
+.vscode/**.json linguist-language=jsonc
 *.json text eol=lf
 *.md text eol=lf
 *.tf text eol=lf


### PR DESCRIPTION
This is to help highlighting in GitHub UI, so comments are no longer treated as "invalid" and no longer highlighted as red.

See https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes