### PR TITLE
dependabot: Reduce interval for dev dependencies to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,14 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+    allow:
+      - dependency-type: "production"
+
+  - package-ecosystem: "npm"
+    versioning-strategy: lockfile-only
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    allow:
+      - dependency-type: "development"


### PR DESCRIPTION
The motivation is to reduce the noise coming mainly from frequently updated `@types/*` packages which are not critical for us, along with most dev dependencies.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval