### PR TITLE
Revert "dependabot: Reduce interval for dev dependencies to weekly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,3 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
-    allow:
-      - dependency-type: "production"
-
-  - package-ecosystem: "npm"
-    versioning-strategy: lockfile-only
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels: ["dependencies"]
-    allow:
-      - dependency-type: "development"


### PR DESCRIPTION
This reverts commit 6256facdcd920e747c132733e063d483b48bbe6d.

GitHub/dependabot does not seem to allow different schedules for the same ecosystem/directory/branch.

> The property ‘#/updates/1’ is a duplicate. Update configs must have a unique combination of ‘package-ecosystem’, ‘directory’, and ‘target-branch’