### PR TITLE
Walk back Language activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "activationEvents": [
     "onLanguage:hcl",
-    "workspaceContains:**/*.hcl",
-    "workspaceContains:**/*.nomad"
+    "workspaceContains:**/*.hcl"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
This removes the `.nomad` file extension from activationEvents

Previously the intention was to handle every HashiCorp product file extension that uses HCL as it's language, and then remove from this extension if/when new VS Code extensions are made. We're going to take the pragmatic approach of providing HCL only first and then see how user adoption flows.
