### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [0.1.1] (2022-05-20)
+
+BUG FIXES:
+
+ - Variables with no space between them break syntax highlighting by @kamilturek in https://github.com/hashicorp/syntax/pull/34
+
+ENHANCEMENTS:
+
+ - Use theme-universal icon with solid background by @radeksimko in https://github.com/hashicorp/vscode-hcl/pull/90
+
+INTERNAL:
+
+ - build(deps-dev): bump glob from 7.2.0 to 7.2.3 by @dependabot in https://github.com/hashicorp/vscode-hcl/pull/83
+ - build(deps-dev): bump @typescript-eslint/eslint-plugin from 5.23.0 to 5.25.0 by @dependabot in https://github.com/hashicorp/vscode-hcl/pull/87
+ - build(deps-dev): bump @typescript-eslint/parser from 5.23.0 to 5.25.0 by @dependabot in https://github.com/hashicorp/vscode-hcl/pull/88
+ - build(deps-dev): bump vsce from 2.7.0 to 2.8.0 by @dependabot in https://github.com/hashicorp/vscode-hcl/pull/89
+
+
+**Full Changelog**: https://github.com/hashicorp/vscode-hcl/compare/v0.1.0...v0.1.1
+
 ## [0.1.0] (2022-05-13)
 
 ENHANCEMENTS:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hcl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hcl",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.4.9"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "displayName": "HashiCorp HCL",
   "description": "HashiCorp HCL syntax",
   "appInsightsKey": "885372d2-6f3c-499f-9d25-b8b219983a52",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MPL-2.0",
   "preview": false,
   "private": true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "preview": false,
   "private": true,
   "syntax": {
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "engines": {
     "npm": "~8.X",


### PR DESCRIPTION
This bumps the syntax to latest (0.3.0) and prepares for 0.1.1 release via `npm version --no-git-tag-version 0.1.1`.