### PR TITLE
ci: fix release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Upload vsix as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.vsce_target }}
           path: "*.vsix"
 
   publish:


### PR DESCRIPTION
Previously the automated release failed:

https://github.com/hashicorp/vscode-hcl/runs/6425955257?check_suite_focus=true

```
Run actions/upload-artifact@v2
  with:
    path: *.vsix
    if-no-files-found: warn
With the provided path, there will be 1 file uploaded
Starting artifact upload
For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
Error: Artifact name: , is incorrectly provided
```