### PR TITLE
Measure usage of known products

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -43,19 +43,18 @@ export function deactivateExtension() {
 }
 
 function detectProduct(doc: vscode.TextDocument) {
-  let product = undefined;
-
   if (doc.fileName === 'waypoint.hcl') {
-    product = 'waypoint';
-  } else if (doc.fileName.endsWith('pkr.hcl') || doc.fileName.endsWith('pkrvars.hcl')) {
-    product = 'packer';
-  } else if (doc.fileName.endsWith('nomad')) {
-    product = 'nomad';
-  } else if (doc.fileName.endsWith('hcl')) {
-    product = 'hcl';
-  } else {
-    product = undefined;
+    return 'waypoint';
+  }
+  if (doc.fileName.endsWith('pkr.hcl') || doc.fileName.endsWith('pkrvars.hcl')) {
+    return 'packer';
+  }
+  if (doc.fileName.endsWith('nomad')) {
+    return 'nomad';
+  }
+  if (doc.fileName.endsWith('hcl')) {
+    return 'hcl';
   }
 
-  return product;
+  return undefined;
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import * as vscode from 'vscode';
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import * as vscode from 'vscode';
 
@@ -14,9 +15,48 @@ export function activateExtension(context: vscode.ExtensionContext) {
 
   reporter.sendTelemetryEvent('startExtension');
   outputChannel.appendLine(`Started: HCL ${vscode.env.appHost}`);
+
+  vscode.workspace.onDidOpenTextDocument((document) => {
+    if (document === undefined) {
+      return;
+    }
+
+    if (document.isUntitled) {
+      // Untitled files are files which haven't been saved yet,
+      // so we don't know if they are hcl so we return
+      return;
+    }
+
+    const product = detectProduct(document);
+    if (product === undefined) {
+      return;
+    }
+
+    reporter.sendTelemetryEvent('textDocument/didOpen', {
+      type: product,
+    });
+  });
 }
 
 export function deactivateExtension() {
   reporter.sendTelemetryEvent('stopExtension');
   outputChannel.appendLine(`Stopped: HCL ${vscode.env.appHost}`);
+}
+
+function detectProduct(doc: vscode.TextDocument) {
+  let product = undefined;
+
+  if (doc.fileName === 'waypoint.hcl') {
+    product = 'waypoint';
+  } else if (doc.fileName.endsWith('pkr.hcl') || doc.fileName.endsWith('pkrvars.hcl')) {
+    product = 'packer';
+  } else if (doc.fileName.endsWith('nomad')) {
+    product = 'nomad';
+  } else if (doc.fileName.endsWith('hcl')) {
+    product = 'hcl';
+  } else {
+    product = undefined;
+  }
+
+  return product;
 }


### PR DESCRIPTION
Having an idea of which products are used by the user base would be useful for future planning. Such data could back up any potential plans and decisions around dedicated extensions for individual products. For example, if we knew that e.g. 60% users open Packer files and 30% Waypoint, then that gives us indication on what extensions are in demand and that could inform future plans.
