### PR TITLE
telemetry: Measure Terraform usage too

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -46,13 +46,16 @@ function detectProduct(doc: vscode.TextDocument) {
   if (doc.fileName === 'waypoint.hcl') {
     return 'waypoint';
   }
-  if (doc.fileName.endsWith('pkr.hcl') || doc.fileName.endsWith('pkrvars.hcl')) {
+  if (doc.fileName.endsWith('.pkr.hcl') || doc.fileName.endsWith('.pkrvars.hcl')) {
     return 'packer';
   }
-  if (doc.fileName.endsWith('nomad')) {
+  if (doc.fileName.endsWith('.tf') || doc.fileName.endsWith('.tfvars')) {
+    return 'terraform';
+  }
+  if (doc.fileName.endsWith('.nomad')) {
     return 'nomad';
   }
-  if (doc.fileName.endsWith('hcl')) {
+  if (doc.fileName.endsWith('.hcl')) {
     return 'hcl';
   }
 


### PR DESCRIPTION
Ideally majority/everyone should be using the Terraform extension as opposed to this HCL one. That is also why the extension doesn't support Terraform out of the box (file associations don't include `*.tf` or `*.tfvars`).

Users would have to add something like this into their configuration

```json
  "files.associations": {
    "*.tf": "hashicorp.hcl"
    "*.tfvars": "hashicorp.hcl"
  }
```
It would be useful to know how many actually do that.

--- 

Aside from that I also added dots to all conditions, to avoid (probably rare) false positives with e.g. `foonomad` or `nomad` and similar.