### PR TITLE
telemetry: further break down language IDs

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -46,11 +46,23 @@ function detectProduct(doc: vscode.TextDocument) {
   if (doc.fileName === 'waypoint.hcl') {
     return 'waypoint';
   }
-  if (doc.fileName.endsWith('.pkr.hcl') || doc.fileName.endsWith('.pkrvars.hcl')) {
+  if (doc.fileName.endsWith('.pkr.hcl')) {
     return 'packer';
   }
-  if (doc.fileName.endsWith('.tf') || doc.fileName.endsWith('.tfvars')) {
+  if (doc.fileName.endsWith('.pkrvars.hcl')) {
+    return 'packer-vars'
+  }
+  if (doc.fileName.endsWith('.tf')) {
     return 'terraform';
+  }
+  if (doc.fileName.endsWith('.tfvars')) {
+    return 'terraform-vars'
+  }
+  if (doc.fileName === '.terraform.lock.hcl') {
+    return 'terraform-lock';
+  }
+  if (doc.fileName === 'terragrunt.hcl') {
+    return 'terragrunt'
   }
   if (doc.fileName.endsWith('.nomad')) {
     return 'nomad';


### PR DESCRIPTION
We can always aggregate the individual language IDs, such as `terraform` & `terraform-vars` if we want to.

It may however be useful, esp. when/if an extension is planned for any language, which exact language is in heavy/light use - to help further prioritize support of e.g. Packer variable files.

I'm also adding two more languages since there seems to be still quite a large part of the piechart occupied by unidentified `hcl`. This may very well be Consul or Vault configs, but we have no way of knowing as they don't follow any naming conventions (yet).

Therefore I'm attempting a process of elimination here by adding Terragrunt and Terraform lock files.