### PR TITLE
Add Sentinel to telemetry

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -46,6 +46,9 @@ function detectProduct(doc: vscode.TextDocument) {
   if (doc.fileName === 'waypoint.hcl') {
     return 'waypoint';
   }
+  if (doc.fileName === 'sentinel.hcl') {
+    return 'sentinel';
+  }
   if (doc.fileName.endsWith('.pkr.hcl')) {
     return 'packer';
   }


### PR DESCRIPTION
It would be useful to track usage of the root sentinel config file (`sentinel.hcl`) to determine how many users use the extension for Sentinel.