### PR TITLE
Polyfill path module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.3.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@vscode/extension-telemetry": "^0.5.2"
+        "@vscode/extension-telemetry": "^0.5.2",
+        "path-browserify": "^1.0.1"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -4756,6 +4757,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -10335,6 +10341,11 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
   },
   "dependencies": {
-    "@vscode/extension-telemetry": "^0.5.2"
+    "@vscode/extension-telemetry": "^0.5.2",
+    "path-browserify": "^1.0.1"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,7 @@ const webExtensionConfig = {
       // see https://webpack.js.org/configuration/resolve/#resolvefallback
       // for the list of Node.js core module polyfills.
       assert: require.resolve('assert'),
+      path: require.resolve('path-browserify'),
     },
   },
   module: {


### PR DESCRIPTION
This PR adds a polyfill for the `path` module (introduced to fix product detection in #176). When building for the web, the node.js module `path` isn't available.