### PR TITLE
Add CI step to publish extension to OpenVSX

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           path: "*.vsix"
 
   publish:
-    name: Publish All
+    name: Publish All (Microsoft Marketplace)
     runs-on: ubuntu-latest
     needs: build
     if: success() && startsWith( github.ref, 'refs/tags/v')
@@ -45,3 +45,15 @@ jobs:
         run: npx vsce publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  publish-ovsx:
+    name: Publish All (OpenVSX)
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() && startsWith( github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: Publish Extension
+        run: npx ovsx publish --packagePath $(find . -iname *.vsix)
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
This PR adds a publishing step for OpenVSX. I've backfilled all the previous versions and added the `OVSX_PAT` as repository secret.

Closes #97