### PR TITLE
deps: bump syntax to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "preview": false,
   "private": true,
   "syntax": {
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "engines": {
     "npm": "~8.X",


### PR DESCRIPTION
This is to bring in https://github.com/hashicorp/syntax/pull/49