### PR TITLE
fix(language-configuration): use # as .hcl file line comment

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,7 @@
 {
   "comments": {
     // symbol used for single line comment. Remove this entry if your language does not support line comments
-    "lineComment": "//",
+    "lineComment": "#",
     // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
     "blockComment": ["/*", "*/"]
   },


### PR DESCRIPTION
Doc: Terraform language supports three different syntaxes for comments. The `#` single-line comment style is the default comment style and should be used in most cases.