### PR TITLE
github: Revert upgrade of artifact actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Package VSIX
         run: npm run package
       - name: Upload VSIX as artifact
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: "*.vsix"
 
@@ -41,7 +41,7 @@ jobs:
     needs: build
     if: success() && startsWith( github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       - name: Publish Extension
         run: npx vsce publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
@@ -53,7 +53,7 @@ jobs:
     needs: build
     if: success() && startsWith( github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       - name: Publish Extension
         run: npx ovsx publish --packagePath $(find . -iname *.vsix)
         env:


### PR DESCRIPTION
This _partially_ reverts https://github.com/hashicorp/vscode-hcl/pull/280 as a way of preventing any effects of a known upstream issue with the new version as discussed in https://github.com/actions/download-artifact/issues/249