### PR TITLE
Use hash instead of double slashes for single line comments

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,7 @@
 {
   "comments": {
     // symbol used for single line comment. Remove this entry if your language does not support line comments
-    "lineComment": "//",
+    "lineComment": "#",
     // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
     "blockComment": ["/*", "*/"]
   },


### PR DESCRIPTION
HCL syntax accepts both `#` and `//` for line comments, but `#` is more idiomatic.

This is also mentioned in Terraform documentation:

> The # single-line comment style is the default comment style and should be used in most cases. Automatic configuration formatting tools may automatically transform // comments into # comments, **since the double-slash style is not idiomatic.**

https://developer.hashicorp.com/terraform/language/syntax/configuration#comments