### PR TITLE
chore: Detect Terraform Stacks, Deploy, Test, and Mock files

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -74,6 +74,18 @@ function detectProduct(doc: vscode.TextDocument) {
   if (fileName === '.terraform.lock.hcl') {
     return 'terraform-lock';
   }
+  if (fileName.endsWith('.tfstack.hcl')) {
+    return 'terraform-stack';
+  }
+  if (fileName.endsWith('.tfdeploy.hcl')) {
+    return 'terraform-deploy';
+  }
+  if (fileName.endsWith('.tftest.hcl')) {
+    return 'terraform-test';
+  }
+  if (fileName.endsWith('.tfmock.hcl')) {
+    return 'terraform-mock';
+  }
   if (fileName === 'terragrunt.hcl') {
     return 'terragrunt';
   }


### PR DESCRIPTION
There are new files that are (going to be) supported by the Terraform Extension, hence it might make sense for us to be able to know when usage for those filetypes spikes in this extension instead.