### PR TITLE
Update syntax version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "preview": false,
   "private": true,
   "syntax": {
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "engines": {
     "npm": "~10.X",


### PR DESCRIPTION
This commit updates the syntax version to 0.7.1, which fixes parsing expressions containing an open curly brace as blocks in https://github.com/hashicorp/syntax/pull/149
